### PR TITLE
Add component_rating table with foreign keys (Closes #16)

### DIFF
--- a/component_rating_table.sql
+++ b/component_rating_table.sql
@@ -1,0 +1,14 @@
+/* 
+ * PRIMARY KEY (component_id, review_id) ensures uniqueness per component-review pair.
+ * FOREIGN KEY (component_id) links each rating to a specific review component.
+ * FOREIGN KEY (review_id) links each rating to a specific user review.
+ * ON DELETE CASCADE ensures cleanup if related records are deleted.
+ */
+CREATE TABLE component_rating (
+    component_id INT NOT NULL,
+    review_id INT NOT NULL,
+    rating INT NOT NULL,
+    PRIMARY KEY (component_id, review_id),
+    FOREIGN KEY (component_id) REFERENCES review_component(id) ON DELETE CASCADE,
+    FOREIGN KEY (review_id) REFERENCES user_review(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
…review @LisanzaTabby 

- Created a new SQL file to define the `component_rating` join table.
- Columns:
  - `component_id` INT NOT NULL
  - `review_id` INT NOT NULL
  - `rating` INT NOT NULL
- Composite primary key on (`component_id`, `review_id`)
- Foreign key:
  - `component_id` → `review_component(id)` (ON DELETE CASCADE)
  - `review_id` → `user_review(id)` (ON DELETE CASCADE)

This file can be run independently without modifying the base schema in `airbnb.sql`.

Closes #16